### PR TITLE
don't use writeFileSync.  instead make save accept a callback

### DIFF
--- a/elxml.js
+++ b/elxml.js
@@ -981,7 +981,7 @@ Workbook.prototype = {
      * @param name  the file name {string}
      * @desc saves the workbook as a Excel 2010 file.
      */
-    save : function(fileName) {
+    save : function(fileName, cb) {
 
         var zip = new JSZip();
         var relsFolder   = zip.folder("_rels");
@@ -1016,7 +1016,7 @@ Workbook.prototype = {
 
         // create zip
         var data = zip.generate({base64:false,compression:'DEFLATE'});
-        fs.writeFileSync(fileName, data, 'binary');
+        fs.writeFile(fileName, data, 'binary', cb);
         return fileName;
     },
     // internal stuff below this line

--- a/tests/test.js
+++ b/tests/test.js
@@ -49,5 +49,9 @@ cell.setValue("2014-02-02");
 cell.setStyle(dateStyle);
 
 // create the file
-wb.save("test.01.xlsx");
+wb.save("test.01.xlsx", function(err){
+	if (err){
+		process.exit(1);
+	}
+});
 


### PR DESCRIPTION
it's good for business anyway, but more importantly this appears to be the only change necessary to make this work with browserify and browserify-fs.
