### PR TITLE
fix column widths, fix textWrap

### DIFF
--- a/elxml.js
+++ b/elxml.js
@@ -345,6 +345,7 @@ Column.prototype = {
         col.att("max", this._max);
         if (this._width > 0) {
             col.att("width", this._width);
+            col.att("customWidth", "1");
         }
         if (this._bestFit != undefined) {
             col.att("bestFit", this._bestFit);
@@ -419,9 +420,10 @@ Fonts.prototype = {
     }
 };
 
-function CellAlignment(h, v) {
+function CellAlignment(h, v, wrap) {
     this.h = h;
     this.v = v;
+    this.wrap = !!wrap;
 }
 CellAlignment.prototype = {
     constructor : CellAlignment,
@@ -613,8 +615,8 @@ function CellStyle(name, id) {
 }
 CellStyle.prototype = {
     constructor : CellStyle,
-    setAlignment : function(h, v) {
-        this.alignment = new CellAlignment(h,v);
+    setAlignment : function(h, v, w) {
+        this.alignment = new CellAlignment(h,v,w);
         this.applyAlignment = 1;
         return this;
     },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "git://github.com/dunkelrot/elxml"
   },
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "arndt.teinert@gmx.de>",
   "contributors": [
     {


### PR DESCRIPTION
1. Without attribute customWidth, xlsx ignores column width set by user. So I added col.att("customWidth", "1") into column save
2. I didn't understand how to control text wrapping using your API. So I added third boolean parameter into setAlignment(w, h, wrap) function which controls the wrapping